### PR TITLE
package name is a parameter, fixing usage of the rpm provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake',                     :require => false
+  gem 'rake', '~> 10.5.0',        :require => false if RUBY_VERSION < '1.9.3'
+  gem 'rake',                     :require => false if RUBY_VERSION >= '1.9.3'
   gem 'rspec', '~>3.1.0',         :require => false
   gem 'rspec-puppet', '~>2.x',    :require => false
   gem 'rspec-puppet-facts',       :require => false

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ This is an example of using a local yum repository to install NHC.
 
     nhc::install_from_repo: 'foo-repo'
 
+This is an other example of using a custom package url.
+
+    nhc::package_url: "http://warewulf.lbl.gov/downloads/repo/rhel6/warewulf-nhc-1.4.1-1.el6.noarch.rpm"
+    nhc::package_name: "warewulf-nhc-1.4.1-1.el6.noarch"
+
 ## Reference
 
 ### Public Classes
@@ -94,6 +99,7 @@ $::osfamily == 'RedHat'
     nhc::package_version: '1.4.2'
     nhc::package_release: '1'
     nhc::package_url: "https://github.com/mej/nhc/releases/download/%VERSION%/lbnl-nhc-%VERSION%-%RELEASE%.el%{::operatingsystemmajrelease}.noarch.rpm"
+    nhc::package_name: "lbnl-nhc-%VERSION%-%RELEASE%.el${::operatingsystemmajrelease}.noarch"
     nhc::install_from_repo: undef
     nhc::checks: []
     nhc::settings: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class nhc (
   if $install_from_repo {
     $_package_require             = Yumrepo[$install_from_repo]
     $_package_source              = undef
-    $_package_name                = 'libnl-nhc'
+    $_package_name                = 'lbnl-nhc'
     $_package_provider            = 'yum'
   } else {
     $_package_require             = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class nhc (
   $package_version            = '1.4.2',
   $package_release            = '1',
   $package_url                = undef,
+  $package_name               = undef,
   $install_from_repo          = undef,
 
   # NHC configuration
@@ -64,12 +65,16 @@ class nhc (
   if $install_from_repo {
     $_package_require             = Yumrepo[$install_from_repo]
     $_package_source              = undef
+    $_package_name                = 'libnl-nhc'
     $_package_provider            = 'yum'
   } else {
     $_package_require             = undef
     $_package_url_version         = regsubst($nhc::params::package_url, '%VERSION%', $package_version, 'G')
     $_package_url_version_release = regsubst($_package_url_version, '%RELEASE%', $package_release)
     $_package_source              = pick($package_url, $_package_url_version_release)
+    $_package_name_version        = regsubst($nhc::params::package_name, '%VERSION%', $package_version, 'G')
+    $_package_name_version_release= regsubst($_package_name_version, '%RELEASE%', $package_release)
+    $_package_name                = pick($package_name, $_package_name_version_release)
     $_package_provider            = 'rpm'
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class nhc::install {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  package { 'lbnl-nhc':
+  package { $nhc::_package_name:
     ensure   => $nhc::_package_ensure,
     source   => $nhc::_package_source,
     provider => $nhc::_package_provider,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class nhc::params {
   case $::osfamily {
     'RedHat': {
       $package_url    = "https://github.com/mej/nhc/releases/download/%VERSION%/lbnl-nhc-%VERSION%-%RELEASE%.el${::operatingsystemmajrelease}.noarch.rpm"
+      $package_name   = "lbnl-nhc-%VERSION%-%RELEASE%.el${::operatingsystemmajrelease}.noarch"
       $program_name   = 'nhc'
       $conf_dir       = '/etc/nhc'
       $conf_file      = '/etc/nhc/nhc.conf'

--- a/spec/classes/nhc_spec.rb
+++ b/spec/classes/nhc_spec.rb
@@ -22,9 +22,9 @@ describe 'nhc' do
 
       context "nhc::install" do
         it do
-          should contain_package('lbnl-nhc').only_with({
+          should contain_package("lbnl-nhc-1.4.2-1.el#{facts[:operatingsystemmajrelease]}.noarch").only_with({
             :ensure   => 'installed',
-            :name     => 'lbnl-nhc',
+            :name     => "lbnl-nhc-1.4.2-1.el#{facts[:operatingsystemmajrelease]}.noarch",
             :source   => "https://github.com/mej/nhc/releases/download/1.4.2/lbnl-nhc-1.4.2-1.el#{facts[:operatingsystemmajrelease]}.noarch.rpm",
             :provider => 'rpm',
           })
@@ -67,7 +67,7 @@ describe 'nhc' do
 
         context 'when ensure => "absent"' do
           let(:params) {{ :ensure => "absent" }}
-          it { should contain_package('lbnl-nhc').with_ensure('absent') }
+          it { should contain_package("lbnl-nhc-1.4.2-1.el#{facts[:operatingsystemmajrelease]}.noarch").with_ensure('absent') }
         end
       end
 


### PR DESCRIPTION
Hello, 

So here's my proposition for fixing package name #1 when using the rpm provider. It was tested with the default module (without hiera configuration) and with this configuration:

```
nhc::package_url: "http://warewulf.lbl.gov/downloads/repo/rhel6/warewulf-nhc-1.4.1-1.el6.noarch.rpm"
nhc::package_name: "warewulf-nhc-1.4.1-1.el6.noarch"
```
